### PR TITLE
rename scope as `@verdigris` was already taken

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,11 @@ defaults: &defaults
 jobs:
   include:
     - stage: verify
+      if: (branch = master AND type = push) OR type = pull_request
       script:
         - yarn lint
     - stage: verify
+      if: (branch = master AND type = push) OR type = pull_request
       env:
         - STAGE_NAME=1x-electron
       <<: *defaults

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: cypress/browsers:chrome67
 language: node_js
 
 node_js:
@@ -5,12 +6,17 @@ node_js:
 
 cache:
   yarn: true
-
-install:
-  - yarn
-  - yarn bootstrap
+  directories:
+    - ~/.cache
+  override:
+    - yarn install --frozen-lockfile
+    - yarn cypress verify
 
 defaults: &defaults
+  install:
+    - yarn install
+    - yarn bootstrap
+    - yarn cypress verify
   script:
     - yarn test:ci
     - kill $(jobs -p) || true
@@ -26,26 +32,34 @@ jobs:
       env:
         - STAGE_NAME=1x-electron
       <<: *defaults
-    # - stage: verify
-    #   env:
-    #     - STAGE_NAME=4x-electron
-    #   <<: *defaults
-    # - stage: verify
-    #   env:
-    #     - STAGE_NAME=4x-electron
-    #   <<: *defaults
-    # - stage: verify
-    #   env:
-    #     - STAGE_NAME=4x-electron
-    #   <<: *defaults
-    # - stage: verify
-    #   env:
-    #     - STAGE_NAME=4x-electron
-    #   <<: *defaults
+    - stage: verify
+      if: (branch = master AND type = push) OR type = pull_request
+      env:
+        - STAGE_NAME=4x-electron
+      <<: *defaults
+    - stage: verify
+      if: (branch = master AND type = push) OR type = pull_request
+      env:
+        - STAGE_NAME=4x-electron
+      <<: *defaults
+    - stage: verify
+      if: (branch = master AND type = push) OR type = pull_request
+      env:
+        - STAGE_NAME=4x-electron
+      <<: *defaults
+    - stage: verify
+      if: (branch = master AND type = push) OR type = pull_request
+      env:
+        - STAGE_NAME=4x-electron
+      <<: *defaults
     - stage: publish
       if: branch = master AND type = push
       env:
         - NODE_ENV=production
+      install:
+        - yarn install --frozen-lockfile
+        - yarn bootstrap
+        - yarn cypress verify
       script:
-        - yarn build
+        # - yarn build
         - echo 'Publishing master'

--- a/build/docz/package.json
+++ b/build/docz/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "name": "@verdigris/docz",
+  "name": "@andrew-codes/verdigris-docz",
   "version": "0.0.0",
   "description": "Docz helpers.",
   "license": "MIT",

--- a/build/svg-icon-loader/package.json
+++ b/build/svg-icon-loader/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "name": "@verdigris/svg-icon-loader",
+  "name": "@andrew-codes/verdigris-svg-icon-loader",
   "version": "0.0.0",
   "description": "Svg icon webpack loader.",
   "license": "MIT",

--- a/build/webpack-config/bin/build-icons.js
+++ b/build/webpack-config/bin/build-icons.js
@@ -28,7 +28,7 @@ async function runDevServer() {
           test: /\.icon\.svg$/,
           loaders: [
             require.resolve('babel-loader'),
-            require.resolve('@verdigris/svg-icon-loader'),
+            require.resolve('@andrew-codes/verdigris-svg-icon-loader'),
           ],
         },
         {

--- a/build/webpack-config/package.json
+++ b/build/webpack-config/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "name": "@verdigris/webpack-config",
+  "name": "@andrew-codes/verdigris-webpack-config",
   "description": "Webpack configuration for running dev server and building Verdigris website.",
   "version": "0.0.0",
   "license": "MIT",
@@ -13,7 +13,7 @@
     "webpack-dev": "bin/dev.js"
   },
   "dependencies": {
-    "@verdigris/svg-icon-loader": "^0.0.0",
+    "@andrew-codes/verdigris-svg-icon-loader": "^0.0.0",
     "uglifyjs-webpack-plugin": "^1.2.5",
     "webpack": "^4.6.0",
     "webpack-bundle-analyzer": "^2.11.1"

--- a/build/webpack-config/src/createConfig.js
+++ b/build/webpack-config/src/createConfig.js
@@ -30,7 +30,7 @@ module.exports = ({
         test: /\.icon\.svg$/,
         loaders: [
           require.resolve('babel-loader'),
-          require.resolve('@verdigris/svg-icon-loader'),
+          require.resolve('@andrew-codes/verdigris-svg-icon-loader'),
         ],
       },
       {

--- a/components/analytics/docs/analytics.mdx
+++ b/components/analytics/docs/analytics.mdx
@@ -4,9 +4,9 @@ route: /packages/analytics
 menu: 3. Components
 ---
 
-import Chip from '@verdigris/chip'
+import Chip from '@andrew-codes/verdigris-chip'
 import { Component } from 'react';
-import { Playground, PropsTable } from '@verdigris/docz'
+import { Playground, PropsTable } from '@andrew-codes/verdigris-docz'
 import { AnalyticsContext, AnalyticsListener, withAnalytics } from '../src'
 
 ## Usage

--- a/components/analytics/package.json
+++ b/components/analytics/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@verdigris/analytics",
+  "name": "@andrew-codes/verdigris-analytics",
   "version": "0.0.0",
   "description": "Capture UI interactions, state, and contextual data from components.",
   "license": "MIT",
@@ -21,7 +21,7 @@
     "prop-types": "^15.6.1"
   },
   "devDependencies": {
-    "@verdigris/docz": "^0.0.0",
+    "@andrew-codes/verdigris-docz": "^0.0.0",
     "lodash": "^4.17.10"
   }
 }

--- a/components/chip/docs/chip.mdx
+++ b/components/chip/docs/chip.mdx
@@ -5,7 +5,7 @@ menu: 3. Components
 ---
 
 import { Fragment } from 'react'
-import { Playground, PropsTable } from '@verdigris/docz'
+import { Playground, PropsTable } from '@andrew-codes/verdigris-docz'
 import Chip from '../src'
 import ChipSrc from '../src/Chip'
 

--- a/components/chip/examples/02-theming-chips.js
+++ b/components/chip/examples/02-theming-chips.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import Chip from '../src/index';
 import { css } from 'emotion';
-import { extendThemeWith } from '@verdigris/theme';
+import { extendThemeWith } from '@andrew-codes/verdigris-theme';
 import { ThemeProvider } from 'emotion-theming';
 
 const AssetLink = ({ href, oidToken, children }) => (

--- a/components/chip/package.json
+++ b/components/chip/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@verdigris/chip",
+  "name": "@andrew-codes/verdigris-chip",
   "version": "0.0.0",
   "description": "Concise representation of an otherwise more complex entity.",
   "license": "MIT",
@@ -18,9 +18,9 @@
     "react": "^16.4.1"
   },
   "dependencies": {
-    "@verdigris/analytics": "^0.0.0",
-    "@verdigris/icons": "^0.0.0",
-    "@verdigris/theme": "^0.0.0",
+    "@andrew-codes/verdigris-analytics": "^0.0.0",
+    "@andrew-codes/verdigris-icons": "^0.0.0",
+    "@andrew-codes/verdigris-theme": "^0.0.0",
     "emotion": "^9.2.4",
     "emotion-theming": "^9.2.4",
     "lodash": "^4.17.10",
@@ -28,6 +28,6 @@
     "react-emotion": "^9.2.4"
   },
   "devDependencies": {
-    "@verdigris/docz": "^0.0.0"
+    "@andrew-codes/verdigris-docz": "^0.0.0"
   }
 }

--- a/components/chip/src/Chip.js
+++ b/components/chip/src/Chip.js
@@ -2,8 +2,8 @@ import styled from 'react-emotion';
 import React from 'react';
 import PropTypes from 'prop-types';
 import { css } from 'emotion';
-import { CloseIcon } from '@verdigris/icons';
-import { defaultTheme } from '@verdigris/theme';
+import { CloseIcon } from '@andrew-codes/verdigris-icons';
+import { defaultTheme } from '@andrew-codes/verdigris-theme';
 import { noop } from 'lodash';
 import { ThemeProvider, withTheme } from 'emotion-theming';
 

--- a/components/chip/src/index.js
+++ b/components/chip/src/index.js
@@ -1,4 +1,4 @@
-import { withAnalytics } from '@verdigris/analytics';
+import { withAnalytics } from '@andrew-codes/verdigris-analytics';
 import Chip from './Chip';
 
 export default withAnalytics()(Chip);

--- a/components/code/docs/code-block.mdx
+++ b/components/code/docs/code-block.mdx
@@ -4,7 +4,7 @@ route: /packages/code/components/CodeBlock
 menu: 3. Components
 ---
 import { Fragment } from 'react'
-import { Playground, PropsTable } from '@verdigris/docz'
+import { Playground, PropsTable } from '@andrew-codes/verdigris-docz'
 import { CodeBlock } from '../src'
 
 ## Usage

--- a/components/code/docs/inline-code.mdx
+++ b/components/code/docs/inline-code.mdx
@@ -4,7 +4,7 @@ route: /packages/code/components/InlineCode
 menu: 3. Components
 ---
 import { Fragment } from 'react'
-import { Playground, PropsTable } from '@verdigris/docz'
+import { Playground, PropsTable } from '@andrew-codes/verdigris-docz'
 import { InlineCode } from '../src'
 
 ## Usage

--- a/components/code/package.json
+++ b/components/code/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@verdigris/code",
+  "name": "@andrew-codes/verdigris-code",
   "version": "0.0.0",
   "description": "Components for rendering inline or block level code.",
   "license": "MIT",

--- a/components/icons/docs/icons.mdx
+++ b/components/icons/docs/icons.mdx
@@ -3,7 +3,7 @@ name: Icons
 route: /packages/icons
 menu: 3. Components
 ---
-import { Playground, PropsTable } from '@verdigris/docz'
+import { Playground, PropsTable } from '@andrew-codes/verdigris-docz'
 import IconList from './IconList'
 import { CloseIcon } from '../src'
 import SvgIcon from '../src/SvgIcon'
@@ -15,7 +15,7 @@ Collection of SVG icon files converted to `SvgIcon` components.
 Each icon can be imported as a property of this package.
 
 ```js
-import { CloseIcon } from '@verdigris/icons';
+import { CloseIcon } from '@andrew-codes/verdigris-icons';
 ```
 
 <Playground>

--- a/components/icons/examples/02-theming-icons.js
+++ b/components/icons/examples/02-theming-icons.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { css } from 'emotion';
-import { extendThemeWith } from '@verdigris/theme';
+import { extendThemeWith } from '@andrew-codes/verdigris-theme';
 import { ThemeProvider } from 'emotion-theming';
 import {
   CloseIcon

--- a/components/icons/package.json
+++ b/components/icons/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@verdigris/icons",
+  "name": "@andrew-codes/verdigris-icons",
   "version": "0.0.0",
   "description": "Icon components used in LifeCycle",
   "license": "MIT",
@@ -12,13 +12,13 @@
     "dist"
   ],
   "scripts": {
-    "build": "../../node_modules/@verdigris/webpack-config/bin/build-icons.js ./src/index.js"
+    "build": "../../node_modules/@andrew-codes/verdigris-webpack-config/bin/build-icons.js ./src/index.js"
   },
   "peerDependencies": {
     "react": "^16.4.1"
   },
   "dependencies": {
-    "@verdigris/theme": "^0.0.0",
+    "@andrew-codes/verdigris-theme": "^0.0.0",
     "emotion": "^9.2.4",
     "emotion-theming": "^9.2.4",
     "prop-types": "^15.6.2",

--- a/components/icons/src/SvgIcon.js
+++ b/components/icons/src/SvgIcon.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import styled from 'react-emotion';
 import { css } from 'emotion';
 import { ThemeProvider } from 'emotion-theming';
-import { defaultTheme } from '@verdigris/theme';
+import { defaultTheme } from '@andrew-codes/verdigris-theme';
 import ThemedIcon from './private-utils/ThemedIcon';
 
 const localTheme = () => ({ theme }) => css`

--- a/components/selection/docs/switch.mdx
+++ b/components/selection/docs/switch.mdx
@@ -3,7 +3,7 @@ name: Switch
 route: /packages/selection/components/switch
 menu: 3. Components
 ---
-import { Playground, PropsTable } from '@verdigris/docz'
+import { Playground, PropsTable } from '@andrew-codes/verdigris-docz'
 import { Switch } from '../src'
 import SwitchSrc from '../src/Switch'
 

--- a/components/selection/examples/02-theming-switch.js
+++ b/components/selection/examples/02-theming-switch.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import { Switch } from '../src/index';
 import { ThemeProvider } from 'emotion-theming';
 import { css } from 'emotion';
-import { extendThemeWith } from '@verdigris/theme';
+import { extendThemeWith } from '@andrew-codes/verdigris-theme';
 
 const iosTheme = {
   Switch: ({ Bar, Handle, Label }) => ({ isChecked, isDisabled, theme }) => css`

--- a/components/selection/package.json
+++ b/components/selection/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@verdigris/selection",
+  "name": "@andrew-codes/verdigris-selection",
   "version": "0.0.0",
   "description": "Selection controls; switch, checkbox, and radio button.",
   "license": "MIT",
@@ -12,8 +12,8 @@
     "dist"
   ],
   "dependencies": {
-    "@verdigris/analytics": "^0.0.0",
-    "@verdigris/theme": "^0.0.0",
+    "@andrew-codes/verdigris-analytics": "^0.0.0",
+    "@andrew-codes/verdigris-theme": "^0.0.0",
     "emotion": "^9.2.5",
     "emotion-theming": "^9.2.5",
     "lodash": "^4.17.10",

--- a/components/selection/src/Switch.js
+++ b/components/selection/src/Switch.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'react-emotion';
 import { css } from 'emotion';
-import { defaultTheme } from '@verdigris/theme';
+import { defaultTheme } from '@andrew-codes/verdigris-theme';
 import { noop } from 'lodash';
 import { ThemeProvider } from 'emotion-theming';
 

--- a/components/selection/src/index.js
+++ b/components/selection/src/index.js
@@ -1,4 +1,4 @@
-import { withAnalytics } from '@verdigris/analytics';
+import { withAnalytics } from '@andrew-codes/verdigris-analytics';
 import SwitchSrc from './Switch';
 
 export const Switch = withAnalytics()(SwitchSrc);

--- a/cypress/integration/components/analytics.spec.js
+++ b/cypress/integration/components/analytics.spec.js
@@ -1,6 +1,6 @@
 /// <reference types="Cypress" />
 
-context('@verdigris/analytics', () => {
+context('@andrew-codes/verdigris-analytics', () => {
   before(() => {
     cy.visit('/packages/analytics');
   });

--- a/cypress/integration/components/chip.spec.js
+++ b/cypress/integration/components/chip.spec.js
@@ -1,6 +1,6 @@
 /// <reference types="Cypress" />
 
-context('@verdigris/chip', () => {
+context('@andrew-codes/verdigris-chip', () => {
   before(() => {
     cy.visit('/packages/chip/components/chip');
   });

--- a/cypress/integration/components/code.spec.js
+++ b/cypress/integration/components/code.spec.js
@@ -1,7 +1,7 @@
 /// <reference types="Cypress" />
 import $ from 'jquery';
 
-context('@verdigris/code', () => {
+context('@andrew-codes/verdigris-code', () => {
   before(() => {
     cy.visit('/packages/code/components/codeblock');
   });

--- a/cypress/integration/components/inlinecode.spec.js
+++ b/cypress/integration/components/inlinecode.spec.js
@@ -1,6 +1,6 @@
 /// <reference types="Cypress" />
 
-context('@verdigris/code', () => {
+context('@andrew-codes/verdigris-code', () => {
   before(() => {
     cy.visit('/packages/code/components/inlinecode');
   });

--- a/cypress/integration/components/switch.spec.js
+++ b/cypress/integration/components/switch.spec.js
@@ -1,4 +1,4 @@
-context('@verdigris/switch', () => {
+context('@andrew-codes/verdigris-switch', () => {
   context('<Switch />', () => {
     before(() => {
       cy.visit('/packages/selection/components/switch');

--- a/docs/guides/contributing.mdx
+++ b/docs/guides/contributing.mdx
@@ -95,6 +95,6 @@ Just as in the subject, use the imperative, present tense: "change" not "changed
 
 ### Footer
 
-The footer should contain any information about Breaking Changes and is also the place to reference issues that this commit closes. The footer also contains packages that are affected by this commit in the form of: `affects: @verdigris/package-name`. Multiple packages may be impacted by adding more than one (space delimited).
+The footer should contain any information about Breaking Changes and is also the place to reference issues that this commit closes. The footer also contains packages that are affected by this commit in the form of: `affects: @andrew-codes/verdigris-package-name`. Multiple packages may be impacted by adding more than one (space delimited).
 
 > **Breaking Changes** should start with the word `BREAKING CHANGE`: with a space or two newlines. The rest of the commit message is then used for this.

--- a/docs/guides/tour-of-the-code-base.mdx
+++ b/docs/guides/tour-of-the-code-base.mdx
@@ -13,15 +13,15 @@ This document will outline the general structure of the code, the standards, and
 * `yarn lint`
 * `yarn test` will run all tests via [Cypress](https://cypress.io)
 * `yarn cypress open` will open tests in [Cypress](https://cypress.io) for local development
-* `yarn lerna add --scope @verdigris/package-name dependency-to-add` (see below for details on managing dependencies)
+* `yarn lerna add --scope @andrew-codes/verdigris-package-name dependency-to-add` (see below for details on managing dependencies)
 
 ## Managing Dependencies
 Packages are managed using [lerna](https://lernajs.io/). Each package has its own list of dependencies. Therefore, dependencies are not added at the project root level; rather scoped to a specific package. There are `yarn` scripts to help automate this:
 
 > **Note**: If you run into trouble after installing a new dependency, try running `yarn && yarn bootstrap`.
 
-* **Adding** a new dependency, use `yarn lerna add --scope @verdigris/package-name dependency-name`
-* For **dev dependencies**, add the `--dev` CLI option `yarn lerna add --dev --scope @verdigris/package-name dependency-name`
+* **Adding** a new dependency, use `yarn lerna add --scope @andrew-codes/verdigris-package-name dependency-name`
+* For **dev dependencies**, add the `--dev` CLI option `yarn lerna add --dev --scope @andrew-codes/verdigris-package-name dependency-name`
 * **Removing** dependencies requires deleting the item from the package's `package.json` and re-running `yarn bootstrap` in the project root.
 
 ## Structure

--- a/doczrc.js
+++ b/doczrc.js
@@ -25,7 +25,7 @@ export default {
                   ],
                 },
               },
-              { loader: require.resolve('@verdigris/svg-icon-loader') },
+              { loader: require.resolve('@andrew-codes/verdigris-svg-icon-loader') },
             ],
           },
         ]),

--- a/package.json
+++ b/package.json
@@ -14,10 +14,10 @@
     "build": "lerna run build",
     "prebuild:website": "yarn bootstrap",
     "build:website": "docz build",
-    "test:ci": "start-server-and-test start http://localhost:3000 cy:run:ci",
+    "test:ci": "start-server-and-test start http-get://localhost:3000 cy:run:ci",
     "cy:run": "cypress run",
     "cy:open": "cypress open",
-    "cy:run:ci": "cypress run",
+    "cy:run:ci": "cypress run --parallel --record --key $CYPRESS_KEY",
     "lint:eslint": "eslint --print-config .eslintrc.json | eslint-config-prettier-check && eslint ."
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "name": "@verdigris/ui",
+  "name": "@andrew-codes/verdigris-ui",
   "description": "Collection of components and accompanying documentation site serving as a test bed for re-usable component creation.",
   "version": "0.0.0-development",
   "author": "Andrew Smith <andrew@andrew.codes>",
@@ -36,7 +36,7 @@
     "@babel/polyfill": "^7.0.0",
     "@babel/preset-env": "^7.1.0",
     "@babel/preset-react": "^7.0.0",
-    "@verdigris/svg-icon-loader": "^0.0.0",
+    "@andrew-codes/verdigris-svg-icon-loader": "^0.0.0",
     "babel-eslint": "^9.0.0",
     "babel-loader": "^8.0.2",
     "babel-plugin-emotion": "^9.2.10",

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@verdigris/theme",
+  "name": "@andrew-codes/verdigris-theme",
   "version": "0.0.0",
   "description": "Theming utilities and components.",
   "license": "MIT",

--- a/scripts/bin/new-comp.sh
+++ b/scripts/bin/new-comp.sh
@@ -29,7 +29,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 > components/$name/LICENSE
 # Create package.json
 echo "{
-  \"name\": \"@verdigris/$name\",
+  \"name\": \"@andrew-codes/verdigris-$name\",
   \"version\": \"0.0.0\",
   \"description\": \"$description\",
   \"license\": \"MIT\",
@@ -55,7 +55,7 @@ echo "" > components/$name/src/index.js
 # ## docs directory
 mkdir -p components/$name/docs
 # code docs page (intro.js)
-echo "import { code, md } from '@verdigris/docs';
+echo "import { code, md } from '@andrew-codes/verdigris-docs';
 
 export default () => md\`
 ## $componentName


### PR DESCRIPTION
Chose to use my personal scope, `@andrew-codes` since this is more of a pet project that I do not expect to be used many places. Keeping the verdigris as a prefix to package names, though: `verdigris-`.