### PR TITLE
Correct port number in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,7 @@
 # Verdigris
 
-Set of components and accompanying doc site serving as a test bed for re-usable component creation.
-
-## Quick Start
-
-### Before you Begin
-
-Please ensure you have the proper software installed.
-
-1.  `node -v` should be ^8.5.0, ^10.0.0 [download](https://nodejs.org/en/)
-2.  `yarn -v` should be ^1.3.2 [download](https://yarnpkg.com/lang/en/docs/install/)
-3.  `git --version` should be >= 2.0.0 [download](https://git-scm.com/downloads)
-
-### Running the Docs Site Locally
-
-1.  `git clone git@github.com:andrew-codes/verdigris.git` to clone repository
-2.  `cd verdigris` to change directory into root of project
-3.  `yarn && yarn bootstrap` to install and bootstrap dependencies.
-4.  `yarn start` and navigate to [http://localhost:9000](http://localhost:9000)
+Set of components and accompanying doc site serving as a test bed for re-usable component creation. See [Getting Started](https://verdigris.andrew.codes) to get started.
 
 ## Other Topics
 
-- [Tour of the code base](https://verdigris.andrew.codes/guides/tour-code-base) (structure, conventions, and norms)
-- [Contributing](https://verdigris.andrew.codes/guides/contributing)
 - [License](./LICENSE)

--- a/docs/guides/contributing.mdx
+++ b/docs/guides/contributing.mdx
@@ -29,7 +29,7 @@ Please ensure you have the proper software installed:
 
 1.  Open the terminal and change into project's root directory; `cd verdigris`
 2.  Run `yarn start` in the terminal
-3.  Open Chrome and visit [http://localhost:9000](http://localhost:9000)
+3.  Open Chrome and visit [http://localhost:3000](http://localhost:3000)
 
 ### PR Deployment Preview Sites
 


### PR DESCRIPTION
Docz uses port 3000 by default instead of 9000.